### PR TITLE
add another docker file to .nextcloudignore

### DIFF
--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -1,3 +1,4 @@
+.dockerignore
 .drone
 .git
 .github


### PR DESCRIPTION
`.dockerignore` is not in `.nextcloudignore`, so it ends up being packaged with the Nextcloud app.