### PR TITLE
Use Unixsocket instead of TCP Connection

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -168,7 +168,7 @@ impl Services {
         let (listen_tx, listen_rx) = oneshot::channel();
 
         spawn(async move {
-            let serve = serve(app.clone(), port, serve_rx);
+            let serve = serve(app.clone(), port, String::from(""), serve_rx);
             let listen = listen_loop(app.clone(), listen_rx);
 
             pin_mut!(serve);


### PR DESCRIPTION
This implements using a unix socket. Tested with following Apache Config:

```
ProxyPass /push/ws unix:///var/run/nc.sock|ws://localhost:7867/ws
ProxyPass /push/ unix:///var/run/nc.sock|http://localhost:7867/
ProxyPassReverse /push/ unix:///var/run/nc.sock|http://localhost:7867/
```

If SOCKETPATH env variable is set, this variable will be used as socket path. Example:

`SOCKETPATH=/var/run/nc.sock ./notify_push /var/www/nextcloud/config/config.php`

There might be much potential for improvements as I just wanted to test this as POC.