### PR TITLE
Add to the documentation a rewriteRule in the case of a reverse proxy with apache

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,8 @@ sudo a2enmod proxy_wstunnel
 Then add the following lines to the `<VirtualHost>` block used for the Nextcloud server.
 
 ```apacheconf
-ProxyPass /push/ws ws://127.0.0.1:7867/ws
+RewriteEngine on
+RewriteRule ^/push/ws/?(.*) "ws://127.0.0.1:7867/ws/$1" [P,L]
 ProxyPass /push/ http://127.0.0.1:7867/
 ProxyPassReverse /push/ http://127.0.0.1:7867/
 ```

--- a/lib/SetupWizard.php
+++ b/lib/SetupWizard.php
@@ -296,7 +296,8 @@ WantedBy = multi-user.target
 	}
 
 	public function apacheConfig(): string {
-		return "ProxyPass /push/ws ws://127.0.0.1:7867/ws
+		return "RewriteEngine on
+RewriteRule ^/push/ws/?(.*) \"ws://127.0.0.1:7867/ws/\$1\" [P,L]
 ProxyPass /push/ http://127.0.0.1:7867/
 ProxyPassReverse /push/ http://127.0.0.1:7867/
 ";


### PR DESCRIPTION
The documentation is not good, you have to use RewriteRule with the P tag for the case of a reverse proxy with apache and websocket.
Without this option, we get an error 400 Bad Request on the url wss://cloud.example.com/push/ws.

On the server side we get :

```
Apr 17 00:27:43 nextcloud1 notify_push[12341]: [2021-04-17 00:27:43.862895 +02:00] DEBUG [hyper::proto::h1::io] /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/hyper-0.14.4/src/proto/h1/io.rs:167: parsed 7 headers 
Apr 17 00:27:43 nextcloud1 notify_push[12341]: [2021-04-17 00:27:43.862980 +02:00] DEBUG [hyper::proto::h1::conn] /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/hyper-0.14.4/src/proto/h1/conn.rs:158: incoming body is empty 
Apr 17 00:27:43 nextcloud1 notify_push[12341]: [2021-04-17 00:27:43.863025 +02:00] DEBUG [warp::filter::service] /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/warp-0.3.1/src/filter/service.rs:132: rejected: Rejection(MissingConnectionUpgrade) 
Apr 17 00:27:43 nextcloud1 notify_push[12341]: [2021-04-17 00:27:43.863083 +02:00] DEBUG [hyper::proto::h1::io] /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/hyper-0.14.4/src/proto/h1/io.rs:248: flushed 169 bytes 
```

For a reason that I do not know, if we use ProxyPass, the headers "upgrade: websocket "and "connection: upgrade" are deleted but not with RewriteRule

According to the documentation, you should avoid using RewriteRule because the performance is better with ProxyPass, but I did not find better :
[https://httpd.apache.org/docs/2.4/en/rewrite/flags.html#flag_p](url)

With this change, the client "test_client" connects correctly and receives the notification of updates.
