### PR TITLE
Reflect changes needed for snap variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,23 @@ User=www-data
 WantedBy = multi-user.target
 ```
 
+If you have installed Nextcloud via Snap, you need to use the following file instead and replace `CHANGEME` in `DATABASE_URL` with the value of `dbpassword` from `/var/snap/nextcloud/current/nextcloud/config/config.php`:
+
+```ini
+[Unit]
+Description = Push daemon for Nextcloud clients
+
+[Service]
+Environment=PORT=7867 # Change if you already have something running on this port
+Environment=DATABASE_URL=mysql://nextcloud:CHANGEME@localhost/nextcloud?socket=/tmp/snap.nextcloud/tmp/sockets/mysql.sock
+Environment=REDIS_URL=redis+unix:///tmp/snap.nextcloud/tmp/sockets/redis.sock
+ExecStart=/var/snap/nextcloud/current/nextcloud/extra-apps/notify_push/bin/x86_64/notify_push /var/snap/nextcloud/current/nextcloud/config/config.php
+User=root
+
+[Install]
+WantedBy = multi-user.target
+```
+
 Adjusting the paths and ports as needed.
 
 #### Configuration


### PR DESCRIPTION
When Nextcloud has been installed via Snap, it needs other parameters than it pulls from the config file due to the usage of sockets. The config file reports the sockets under /tmp/sockets/, but the real host directory is /tmp/snap.nextcloud/tmp/sockets.

This check should ultimately be added to notify_push:setup (which should also go as far as installing the unit file and starting the service so that it's a more seamless process for the user).