### PR TITLE
Add sleep to fix test failures on slow machines

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -292,6 +292,7 @@ async fn assert_next_message(
     client: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
     expected: &str,
 ) {
+    sleep(Duration::from_millis(100)).await;
     assert_eq!(
         timeout(Duration::from_millis(200), client.next())
             .await
@@ -430,6 +431,8 @@ async fn test_pre_auth() {
     let services = Services::new().await;
 
     let server_handle = services.spawn_server().await;
+
+    sleep(Duration::from_millis(500)).await;
 
     let mut redis = services.redis_client().await;
     redis


### PR DESCRIPTION
I am packaging this project for Arch Linux RISC-V and have noticed some test failures.

```
running 13 tests
test test_notify_file ... FAILED
test test_notify_activity_other_user ... FAILED
test test_notify_share ... FAILED
test test_auth ... FAILED
test test_notify_file_different_storage ... FAILED
test test_notify_custom_body ... FAILED
test test_notify_custom ... FAILED
test test_auth_failure ... FAILED
test test_notify_file_multiple ... FAILED
test test_notify_activity ... FAILED
test test_notify_group ... FAILED
test test_notify_notification ... FAILED
test test_pre_auth ... FAILED

failures:

---- test_notify_file stdout ----
thread 'test_notify_file' panicked at 'called `Result::unwrap()` on an `Err` value: Elapsed(())', tests/integration.rs:298:14

---- test_notify_activity_other_user stdout ----
thread 'test_notify_activity_other_user' panicked at 'called `Result::unwrap()` on an `Err` value: Elapsed(())', tests/integration.rs:298:14

---- test_notify_share stdout ----
thread 'test_notify_share' panicked at 'called `Result::unwrap()` on an `Err` value: Elapsed(())', tests/integration.rs:298:14

---- test_auth stdout ----
thread 'test_auth' panicked at 'called `Result::unwrap()` on an `Err` value: Elapsed(())', tests/integration.rs:298:14

---- test_notify_file_different_storage stdout ----
thread 'test_notify_file_different_storage' panicked at 'called `Result::unwrap()` on an `Err` value: Elapsed(())', tests/integration.rs:298:14

---- test_notify_custom_body stdout ----
thread 'test_notify_custom_body' panicked at 'called `Result::unwrap()` on an `Err` value: Elapsed(())', tests/integration.rs:298:14

---- test_notify_custom stdout ----
thread 'test_notify_custom' panicked at 'called `Result::unwrap()` on an `Err` value: Elapsed(())', tests/integration.rs:298:14

---- test_auth_failure stdout ----
thread 'test_auth_failure' panicked at 'called `Result::unwrap()` on an `Err` value: Elapsed(())', tests/integration.rs:298:14

---- test_notify_file_multiple stdout ----
thread 'test_notify_file_multiple' panicked at 'called `Result::unwrap()` on an `Err` value: Elapsed(())', tests/integration.rs:298:14

---- test_notify_activity stdout ----
thread 'test_notify_activity' panicked at 'called `Result::unwrap()` on an `Err` value: Elapsed(())', tests/integration.rs:298:14

---- test_notify_group stdout ----
[flexi_logger][ERRCODE::Time] flexi_logger has to work with UTC rather than with local time, caused by IndeterminateOffset
    See https://docs.rs/flexi_logger/latest/flexi_logger/error_info/index.html#time
thread 'test_notify_group' panicked at 'called `Result::unwrap()` on an `Err` value: Elapsed(())', tests/integration.rs:298:14

---- test_notify_notification stdout ----
thread 'test_notify_notification' panicked at 'called `Result::unwrap()` on an `Err` value: Elapsed(())', tests/integration.rs:298:14

---- test_pre_auth stdout ----
thread 'test_pre_auth' panicked at 'assertion failed: `(left == right)`
  left: `Text("err: Invalid credentials")`,
 right: `Text("authenticated")`', tests/integration.rs:295:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    test_auth
    test_auth_failure
    test_notify_activity
    test_notify_activity_other_user
    test_notify_custom
    test_notify_custom_body
    test_notify_file
    test_notify_file_different_storage
    test_notify_file_multiple
    test_notify_group
    test_notify_notification
    test_notify_share
    test_pre_auth

test result: FAILED. 0 passed; 13 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.75s
```

After investigation, this may be caused by the low performance of the current RISC-V machines (QEMU or boards) and some operations taking longer than expected. Adding some reasonable sleep can fix these failures, and that's what the PR did.