### PR TITLE
remove old release packaging ci to avoid confusion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,39 +40,6 @@ jobs:
           asset_name: notify_push-${{ matrix.target }}
           tag: ${{ github.ref }}
 
-  package:
-    name: Package release
-    runs-on: ubuntu-20.04
-    steps:
-      - name: musl-tools
-        run: |
-          sudo apt-get install musl-tools
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          target: x86_64-unknown-linux-musl
-      - name: cross
-        run: |
-          cargo install cross --locked
-      - name: Setup krankler
-        run: |
-          wget https://github.com/ChristophWurst/krankerl/releases/download/v0.13.0/krankerl
-          chmod +x krankerl
-      - name: Package app
-        run: |
-          ./krankerl package
-      - name: Upload binary to release
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: build/artifacts/${{ env.APP_NAME }}.tar.gz
-          asset_name: ${{ env.APP_NAME }}.tar.gz
-          tag: ${{ github.ref }}
-
   build-test-client:
     name: Build test client
     runs-on: ubuntu-20.04


### PR DESCRIPTION
binary builds still remain as they remain usefull for other systems that re-package those

Signed-off-by: Robin Appelman <robin@icewind.nl>