### PR TITLE
fix Cargo failed to select a version for the requirement.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-FROM ekidd/rust-musl-builder AS build
+FROM clux/muslrust:stable AS build
 
 COPY Cargo.toml Cargo.lock ./
 
 # Build with a dummy main to pre-build dependencies
 RUN mkdir src && \
- sudo chown -R rust:rust . && \
  sed -i '/test_client/d' Cargo.toml && \
  echo "fn main(){}" > src/main.rs && \
  cargo build --release && \
@@ -13,13 +12,14 @@ RUN mkdir src && \
 COPY build.rs ./
 COPY appinfo/info.xml ./appinfo/
 COPY src/ ./src/
-RUN sudo chown -R rust:rust . && touch src/main.rs
+RUN touch src/main.rs
 
 RUN cargo build --release
 
 FROM scratch
 
-COPY --from=build /home/rust/src/target/x86_64-unknown-linux-musl/release/notify_push /
+COPY --from=build /volume/target/x86_64-unknown-linux-musl/release/notify_push /
 EXPOSE 7867
 
 CMD ["/notify_push"]
+


### PR DESCRIPTION
Closes #232.

ekidd/rust-musl-builder latest rust version is 1.57.
We might need to replace it with another image to build with the msrv version.