### PR TITLE
Update the SetupWizard to take into account FreeBSD systems.

### DIFF
--- a/lib/BinaryFinder.php
+++ b/lib/BinaryFinder.php
@@ -26,11 +26,15 @@ namespace OCA\NotifyPush;
 class BinaryFinder {
 	public function getArch(): string {
 		$arch = php_uname('m');
+		$os = php_uname('s');
 		if (strpos($arch, 'armv7') === 0) {
 			return 'armv7';
 		}
 		if (strpos($arch, 'aarch64') === 0) {
 			return 'aarch64';
+		}
+		if (strpos($arch, 'amd64') == 0 && strpos($os, 'FreBSD') == 0) {
+			return 'fbsd_amd64';
 		}
 		return $arch;
 	}

--- a/lib/BinaryFinder.php
+++ b/lib/BinaryFinder.php
@@ -33,7 +33,7 @@ class BinaryFinder {
 		if (strpos($arch, 'aarch64') === 0) {
 			return 'aarch64';
 		}
-		if (strpos($arch, 'amd64') == 0 && strpos($os, 'FreBSD') == 0) {
+		if (strpos($arch, 'amd64') == 0 && strpos($os, 'FreeBSD') == 0) {
 			return 'fbsd_amd64';
 		}
 		return $arch;

--- a/lib/BinaryFinder.php
+++ b/lib/BinaryFinder.php
@@ -33,8 +33,8 @@ class BinaryFinder {
 		if (strpos($arch, 'aarch64') === 0) {
 			return 'aarch64';
 		}
-		if (strpos($arch, 'amd64') == 0 && strpos($os, 'FreeBSD') == 0) {
-			return 'fbsd_amd64';
+		if (strpos($os, 'FreeBSD') == 0) {
+			$arch = 'fbsd_' . $arch;
 		}
 		return $arch;
 	}

--- a/lib/Command/Setup.php
+++ b/lib/Command/Setup.php
@@ -71,7 +71,7 @@ class Setup extends Command {
 			if (!$this->setupWizard->hasBundledBinaries()) {
 				$output->writeln("<error>🗴 bundled binaries are not available.</error>");
 				$output->writeln("  If you're trying to setup the app from git, you can find build instruction in the README: https://github.com/nextcloud/notify_push");
-				$output->writeln("  And pre-build binaries for x86_64, armv7 and aarch64 in the github actions.");
+				$output->writeln("  And pre-built binaries for x86_64, armv7, aarch64 and freebsd (amd64) in the github actions.");
 				$output->writeln("  Once you have a <info>notify_push</info> binary it should be placed in <info>" . realpath(__DIR__ . '/../../bin/' . $this->setupWizard->getArch())) . "</info>";
 				return 1;
 			}
@@ -103,6 +103,7 @@ class Setup extends Command {
 			if (!$this->setupWizard->hasBinary()) {
 				$output->writeln("<error>🗴 your system architecture(" . $this->setupWizard->getArch() .") is not supported by the bundled binaries.</error>");
 				$output->writeln("  you can find build instructions for the notify_push binary in the README: https://github.com/nextcloud/notify_push");
+				$output->writeln("  And pre-built binaries for x86_64, armv7, aarch64 and freebsd (amd64) in the github actions.");
 				$output->writeln("  Once you have a <info>notify_push</info> binary it should be placed in <info>" . realpath(__DIR__ . '/../../bin/' . $this->setupWizard->getArch())) . "</info>";
 				return 1;
 			}

--- a/lib/SetupWizard.php
+++ b/lib/SetupWizard.php
@@ -60,7 +60,7 @@ class SetupWizard {
 	}
 
 	public function hasBundledBinaries(): bool {
-		return is_dir(__DIR__ . '/../bin/x86_64');
+		return is_dir(__DIR__ . '/../bin/' . $this->binaryFinder->getArch());
 	}
 
 	public function hasBinary(): bool {


### PR DESCRIPTION
This only solves the first issue of using the setup wizard on freebsd, by clarifying the message about the presence of pre-built binaries.

To make the wizard run fully in FreeBSD, PR#256 needs to be merged, and then hasSystemd() will need to be amended to cover the FreeBSD rc system.