### PR TITLE
Speedup: file_id is always provided for StorageUpdate event

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -12,7 +12,7 @@ use tokio_stream::{Stream, StreamExt};
 pub struct StorageUpdate {
     pub storage: u32,
     pub path: String,
-    pub file_id: Option<u64>,
+    pub file_id: u64,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,7 +1,7 @@
 use crate::connection::ConnectionOptions;
 use parse_display::Display;
 use serde_json::Value;
-use smallvec::SmallVec;
+use smallvec::{smallvec, SmallVec};
 use std::cmp::{max, min};
 use std::fmt::Write;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -30,16 +30,9 @@ impl UpdatedFiles {
     }
 }
 
-impl From<Option<u64>> for UpdatedFiles {
-    fn from(id: Option<u64>) -> Self {
-        match id {
-            Some(id) => {
-                let mut ids = SmallVec::new();
-                ids.push(id);
-                UpdatedFiles::Known(ids)
-            }
-            None => UpdatedFiles::Unknown,
-        }
+impl From<u64> for UpdatedFiles {
+    fn from(id: u64) -> Self {
+        UpdatedFiles::Known(smallvec![id])
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -359,7 +359,7 @@ async fn test_notify_file() {
     redis
         .publish::<_, _, ()>(
             "notify_storage_update",
-            r#"{"storage":10, "path":"foo/bar"}"#,
+            r#"{"storage":10, "path":"foo/bar", "file_id":5}"#,
         )
         .await
         .unwrap();
@@ -382,7 +382,7 @@ async fn test_notify_file_different_storage() {
     redis
         .publish::<_, _, ()>(
             "notify_storage_update",
-            r#"{"storage":11, "path":"foo/bar"}"#,
+            r#"{"storage":11, "path":"foo/bar", "file_id":5}"#,
         )
         .await
         .unwrap();
@@ -414,7 +414,7 @@ async fn test_notify_file_multiple() {
     redis
         .publish::<_, _, ()>(
             "notify_storage_update",
-            r#"{"storage":10, "path":"foo/bar"}"#,
+            r#"{"storage":10, "path":"foo/bar", "file_id":5}"#,
         )
         .await
         .unwrap();


### PR DESCRIPTION
Originally part of https://github.com/nextcloud/notify_push/pull/181