### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -183,12 +183,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "441ea025d4a73ec587e05dfb673a6c143086eba3"
+                "reference": "cb36d570c3b7aae1735599cc4b3614b9ce5c9c79"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/441ea025d4a73ec587e05dfb673a6c143086eba3",
-                "reference": "441ea025d4a73ec587e05dfb673a6c143086eba3",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/cb36d570c3b7aae1735599cc4b3614b9ce5c9c79",
+                "reference": "cb36d570c3b7aae1735599cc4b3614b9ce5c9c79",
                 "shasum": ""
             },
             "require": {
@@ -220,7 +220,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2023-06-24T00:43:35+00:00"
+            "time": "2023-08-26T00:28:49+00:00"
         },
         {
             "name": "phar-io/manifest",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency