### PR TITLE
Follow Caddy's best practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,8 +272,7 @@ sudo systemctl restart apache2
 #### Caddy v2
 
 ```Caddyfile
-route /push/* {
-    uri strip_prefix /push
+handle_path /push/* {
     reverse_proxy http://127.0.0.1:7867
 }
 ```


### PR DESCRIPTION
I made a post in Caddy's community about my Nextcloud's configuration wich includes client_push block as it's shown here and they made this change according to Caddy best practices of handling this route.

Source: https://caddy.community/t/caddy-v2-configuration-nextcloud-docker-php-fpm-with-rules-from-htaccess/20662/2