### PR TITLE
Support SystemD `Type=notify`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,6 +1383,7 @@ dependencies = [
  "rand",
  "redis",
  "reqwest",
+ "sd-notify",
  "serde",
  "serde_json",
  "smallvec",
@@ -2038,6 +2039,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "sd-notify"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "621e3680f3e07db4c9c2c3fb07c6223ab2fab2e54bd3c04c3ae037990f428c32"
 
 [[package]]
 name = "semver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ derivative = "2.2.0"
 nextcloud-config-parser = { version = "0.10.0", features = ["redis-connect"] }
 url = "2.5.0"
 clap = { version = "4.5.4", features = ["derive"] }
+sd-notify = { version = "0.4.1", optional = true }
 
 [dev-dependencies]
 mini-redis = "0.4.1"
@@ -49,3 +50,6 @@ opt-level = 3
 lto = true
 
 [workspace]
+
+[features]
+systemd = ["dep:sd-notify"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,4 +52,5 @@ lto = true
 [workspace]
 
 [features]
+default = ["systemd"]
 systemd = ["dep:sd-notify"]

--- a/README.md
+++ b/README.md
@@ -60,11 +60,14 @@ Documentation=https://github.com/nextcloud/notify_push
 [Service]
 Environment = PORT=7867 # Change if you already have something running on this port
 ExecStart = /path/to/push/binary/notify_push /path/to/nextcloud/config/config.php
+Type=notify # requires the push server to have been build with the systemd feature
 User=www-data
 
 [Install]
 WantedBy = multi-user.target
 ```
+
+If the push server has not been compiled with the optional systemd feature the `Type=notify` line has to be removed.
 
 #### OpenRC
 

--- a/lib/SetupWizard.php
+++ b/lib/SetupWizard.php
@@ -246,6 +246,7 @@ Description = Push daemon for Nextcloud clients
 Environment=PORT=7867
 Environment=NEXTCLOUD_URL=$ncUrl
 {$selfSigned}ExecStart=$path $config
+Type=notify
 User=$user
 
 [Install]

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,6 +26,9 @@ pub enum Error {
     Authentication(#[from] AuthenticationError),
     #[error("Error while communicating with Nextcloud: {0}")]
     NextCloud(#[from] NextCloudError),
+    #[cfg(feature = "systemd")]
+    #[error("Failed to notify SystemD: {0}")]
+    SystemD(#[from] std::io::Error),
 }
 
 #[derive(Debug, Error, Diagnostic)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,6 @@ use notify_push::error::ConfigError;
 use notify_push::message::DEBOUNCE_ENABLE;
 use notify_push::metrics::serve_metrics;
 use notify_push::{listen_loop, serve, App, Error};
-#[cfg(feature = "systemd")]
-use sd_notify;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use tokio::select;


### PR DESCRIPTION
By compiling with the optional feature `systemd` the service representing the push server can be configured with `Type=notify`.

This allows actions depending on the service being operational (like `occ notify_push:setup`) to be delayed until things like connections or Unix domain sockets have been established.

The following things might be debatable:

 - using an external dependency for notifying SystemD

 - notifying SystemD in a blocking manner from within a future
 
Closes #452 