### PR TITLE
Fix build on non-x86_64 archs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,12 @@ RUN touch src/main.rs
 
 RUN cargo build --release
 
+# Pick the executable file for the right architecture and system
+RUN mv /volume/target/*-unknown-*-musl/release/notify_push /notify_push
+
 FROM scratch
 
-COPY --from=build /volume/target/x86_64-unknown-linux-musl/release/notify_push /
+COPY --from=build /notify_push /
 EXPOSE 7867
 
 CMD ["/notify_push"]
-


### PR DESCRIPTION
The current `Dockerfile` only works on linux on x86_64, even if the rust compiler does the job for different architectures, based on the host machine. This fix makes it work on all supported archs and systems - linux and bsd (_untested_) -.