### PR TITLE
Update systemd service example

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ ExecStart = /path/to/push/binary/notify_push /path/to/nextcloud/config/config.ph
 # requires the push server to have been build with the systemd feature (enabled by default)
 Type=notify
 User=www-data
+Restart=always
+RestartSec=60
 
 [Install]
 WantedBy = multi-user.target


### PR DESCRIPTION
In case the service stops for w/e reason it will stay so. By adding Restart=always it is made sure the push server always runs.

Restart sec was chosen arbitrarily to not spam attempts if it fails at startup, there might be better ways to do that.