### PR TITLE
Add soft dependencies to systemd service

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ content.
 
 ```ini
 [Unit]
+After=network.target mariadb.service nginx.service postgresql.service redis.service
 Description = Push daemon for Nextcloud clients
 Documentation = https://github.com/nextcloud/notify_push
 


### PR DESCRIPTION
This `After` clause will ensure that notify_push service will be started after specified services, but all of them are optional and not fatal, even if user does not have them installed, or they fail to start. Thus, this will at worst postpone startup of the service (as intended), but will not result in any failures on its own.

I've noticed this is acceptable in regards to OpenRC service specification below, hence adding it to systemd as well.