### PR TITLE
Suggest optional security hardening in systemd service

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,39 @@ User = www-data
 Restart = always
 RestartSec = 60
 
+# Optional security hardening
+CapabilityBoundingSet=
+DevicePolicy=closed
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+NoNewPrivileges=yes
+PrivateDevices=yes
+PrivateIPC=yes
+PrivateMounts=yes
+PrivateTmp=yes
+PrivateUsers=yes
+ProcSubset=pid
+ProtectClock=yes
+ProtectControlGroups=yes
+ProtectHome=read-only
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectProc=invisible
+ProtectSystem=strict
+RemoveIPC=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+SecureBits=noroot-locked
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged
+SystemCallFilter=~@resources
+UMask=0077
+
 [Install]
 WantedBy = multi-user.target
 ```


### PR DESCRIPTION
This PR adds a few additional `[Service]` systemd entries that are wanted for people that want to ensure additional security bulletproofing on their system.

I verified that `notify_push` service works properly with no errors or warnings upon applying. The configuration is compatible with TCP as well as unix socket creation, it's also compatible with standard `www-data` user as well as custom ones.

I believe this is worthy addition. If you want to make it truly optional, I can also comment out all of those entries, leaving them up to the user to enable. Considering the fact that it doesn't create any apparent issues however, I believe they should be enabled by default.

Thanks in advance for considering this PR.