### PR TITLE
fix: migrate commands to OC\Core\Command\Base class

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -18,6 +18,12 @@ SPDX-FileCopyrightText = "2023 Nextcloud GmbH and Nextcloud contributors"
 SPDX-License-Identifier = "AGPL-3.0-or-later"
 
 [[annotations]]
+path = ["tests/stubs/oc_core_command_base.php"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 Nextcloud GmbH and Nextcloud contributors"
+SPDX-License-Identifier = "AGPL-3.0-or-later"
+
+[[annotations]]
 path = ["img/app.svg", "img/app-dark.svg"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2018-2024 Google LLC"

--- a/lib/Command/Log.php
+++ b/lib/Command/Log.php
@@ -8,14 +8,14 @@ declare(strict_types=1);
 
 namespace OCA\NotifyPush\Command;
 
+use OC\Core\Command\Base;
 use OCA\NotifyPush\Queue\IQueue;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class Log extends Command {
+class Log extends Base {
 	private $queue;
 
 	public function __construct(

--- a/lib/Command/Metrics.php
+++ b/lib/Command/Metrics.php
@@ -8,13 +8,13 @@ declare(strict_types=1);
 
 namespace OCA\NotifyPush\Command;
 
+use OC\Core\Command\Base;
 use OCA\NotifyPush\Queue\IQueue;
 use OCA\NotifyPush\Queue\RedisQueue;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class Metrics extends Command {
+class Metrics extends Base {
 	private $queue;
 
 	public function __construct(

--- a/lib/Command/Metrics.php
+++ b/lib/Command/Metrics.php
@@ -51,6 +51,13 @@ class Metrics extends Base {
 					$output->writeln('<error>Invalid metrics received from push server</error>');
 					return 1;
 				}
+
+				// Output in the requested format if different from plain
+				if ($input->getOption('output') !== self::OUTPUT_FORMAT_PLAIN) {
+					$this->writeArrayInOutputFormat($input, $output, $metrics);
+					return 0;
+				}
+
 				$output->writeln('Active connection count: ' . $metrics['active_connection_count']);
 				$output->writeln('Active user count: ' . $metrics['active_user_count']);
 				$output->writeln('Total connection count: ' . $metrics['total_connection_count']);

--- a/lib/Command/Reset.php
+++ b/lib/Command/Reset.php
@@ -8,12 +8,12 @@ declare(strict_types=1);
 
 namespace OCA\NotifyPush\Command;
 
+use OC\Core\Command\Base;
 use OCA\NotifyPush\Queue\IQueue;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class Reset extends Command {
+class Reset extends Base {
 	private $queue;
 
 	public function __construct(

--- a/lib/Command/SelfTest.php
+++ b/lib/Command/SelfTest.php
@@ -8,12 +8,12 @@ declare(strict_types=1);
 
 namespace OCA\NotifyPush\Command;
 
+use OC\Core\Command\Base;
 use OCP\IConfig;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class SelfTest extends Command {
+class SelfTest extends Base {
 	private $test;
 	private $config;
 

--- a/lib/Command/Setup.php
+++ b/lib/Command/Setup.php
@@ -8,14 +8,14 @@ declare(strict_types=1);
 
 namespace OCA\NotifyPush\Command;
 
+use OC\Core\Command\Base;
 use OCA\NotifyPush\SetupWizard;
 use OCP\IConfig;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class Setup extends Command {
+class Setup extends Base {
 	private $test;
 	private $config;
 	private $setupWizard;

--- a/psalm.xml
+++ b/psalm.xml
@@ -21,6 +21,7 @@
 	</extraFiles>
 	<stubs>
 		<file name="tests/stub.phpstub" preloadClasses="true"/>
+		<file name="tests/stubs/oc_core_command_base.php" />
 		<file name="tests/stubs/symfony_component_console_command_command.php" />
 		<file name="tests/stubs/symfony_component_console_helper_table.php" />
 		<file name="tests/stubs/symfony_component_console_input_inputargument.php" />

--- a/tests/stubs/oc_core_command_base.php
+++ b/tests/stubs/oc_core_command_base.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace OC\Core\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Base class for Nextcloud commands with output formatting support
+ */
+class Base extends Command {
+	public const OUTPUT_FORMAT_PLAIN = 'plain';
+	public const OUTPUT_FORMAT_JSON = 'json';
+	public const OUTPUT_FORMAT_JSON_PRETTY = 'json_pretty';
+
+	protected string $defaultOutputFormat = self::OUTPUT_FORMAT_PLAIN;
+
+	protected function writeArrayInOutputFormat(InputInterface $input, OutputInterface $output, iterable $items, string $prefix = '  - '): void {
+	}
+
+	protected function writeTableInOutputFormat(InputInterface $input, OutputInterface $output, array $items): void {
+	}
+
+	protected function writeStreamingTableInOutputFormat(InputInterface $input, OutputInterface $output, \Iterator $items, int $tableGroupSize): void {
+	}
+
+	protected function writeStreamingJsonArray(InputInterface $input, OutputInterface $output, \Iterator $items): void {
+	}
+
+	public function chunkIterator(\Iterator $iterator, int $count): \Iterator {
+	}
+}


### PR DESCRIPTION
- Fix #561
- Add `--output` flag support
- Copy over usage of commands from server repo to 

Before | After
-- | --
<img width="959" height="428" alt="2026-05-19_16h09_34" src="https://github.com/user-attachments/assets/a2cbf165-f073-4581-8bc7-1f8578c3c35b" /> | <img width="957" height="582" alt="2026-05-19_16h09_57" src="https://github.com/user-attachments/assets/67554d2b-7124-48c8-8d50-c4991225d643" />

- [x] Pr is AI-assisted