### PR TITLE
fix: add missing prefix to log as debug

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -226,7 +226,7 @@ pub async fn handle_user_socket(
                     // hack while warp only has opaque error types
                     match formatted.as_str() {
                         "WebSocket protocol error: Connection reset without closing handshake"
-                        | "Broken pipe (os error 32)"
+                        | "IO error: Broken pipe (os error 32)"
                         | "IO error: Connection reset by peer (os error 104)" => {
                             log::debug!("websocket error: {e:#}")
                         }


### PR DESCRIPTION
Add the missing prefix so the broken-pipe case is downgraded to debug like the other benign disconnects.
Fix https://github.com/nextcloud/notify_push/issues/100